### PR TITLE
hard-code ampache release to pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,14 @@ RUN php -r "readfile('https://getcomposer.org/installer');" | php && \
 
 # For local testing / faster builds
 # COPY master.tar.gz /opt/master.tar.gz
-ADD https://github.com/ampache/ampache/archive/master.tar.gz /opt/ampache-master.tar.gz
+
+ENV AMPACHE_VERSION 3.8.2
+
+ADD https://github.com/ampache/ampache/archive/${AMPACHE_VERSION}.tar.gz /opt/ampache-${AMPACHE_VERSION}.tar.gz
 
 # extraction / installation
 RUN rm -rf /var/www/* && \
-    tar -C /var/www -xf /opt/ampache-master.tar.gz ampache-master --strip=1 && \
+    tar -C /var/www -xf /opt/ampache-${AMPACHE_VERSION}.tar.gz ampache-${AMPACHE_VERSION} --strip=1 && \
     cd /var/www && composer install --prefer-source --no-interaction && \
     chown -R www-data /var/www
 


### PR DESCRIPTION
Addresses a (rightly raised) [concern](https://github.com/ampache/ampache-docker/pull/7#issuecomment-272442892) by @Kernald about pulling from `latest` by default. 

After merging this, please ensure the 3.8.2 tag is pushed to [Docker Hub](https://hub.docker.com/r/ampache/ampache/tags/).