### PR TITLE
Add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+services:
+  - docker
+
+install:
+  - docker build --tag ampache_image .
+
+script:
+  - docker images | grep ampache_image
+  - docker run -d --name=ampache_container -p 1234:80 ampache_image
+  - docker ps | grep ampache_container


### PR DESCRIPTION
checks if ampache image builds and runs properly. 

to be merged after https://github.com/ampache/ampache-docker/pull/8 is reviewed.

don't forget to switch on Travis CI for https://travis-ci.org/ampache/ampache-docker