### PR TITLE
Remove unnecessary volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN     apt-get -q -q update \
           software-properties-common \
     &&  apt-get -qq autoremove
 
-VOLUME ["/etc/mysql", "/var/lib/mysql", "/media", "/var/www/config", "/var/www/themes"]
+VOLUME ["/var/lib/mysql", "/var/www/config"]
 EXPOSE 80
 
 COPY run.sh inotifywatch.sh cron.sh apache2.sh mysql.sh create_mysql_admin_user.sh /usr/local/bin/


### PR DESCRIPTION
I believe we should remove the following volumes:

* /etc/mysql
* /media
* /var/www/themes

We aren't creating custom configuration for MySQL, so I'm not sure we need a volume for that. There is nothing in /media by default, and it doesn't really matter what the path is.

Additionally, any volume listed under the `VOLUME` declaration are created as anonymous volumes unless a user has made them into a named volume, or bind-mounted the directory. When using `docker-compose down`, the associations to anonymous volumes are lost, and new volumes created on the next `up`, which could result in a bunch of junk volumes.

Lastly, for the themes directory if the user has it named/bind mounted then when it's updated in the image, the user will not get any updates to the reborn theme in their instance. It would be better to bind mount new themes to their own directory within `/themes` so that the reborn theme is left alone.