### PR TITLE
Create ampache log folder and make it writeable

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,7 +13,8 @@ fi
 # Re-set permission to the `www-data` user if current user is root
 # This avoids permission denied if the data volume is mounted by root
 if [ "$1" = '/run.sh' ] && [ "$(id -u)" = '0' ]; then
-    chown -R www-data:www-data /var/www/config
+    mkdir -p /var/logs/ampache
+    chown -R www-data:www-data /var/www/config /var/logs/ampache
     exec gosu www-data "$@"
 else
   exec "$@"


### PR DESCRIPTION
By default there is no log folder for ampache to write its logs into.
It first has to be created and ampache (running in apache as the www-data user) has to be given the right to write into the folder.