### PR TITLE
Add hint and command to make /media writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ chown www-data:www-data ./data/config -R
 ```
 
 This will automatically create mount points for music at `./data/media`, persistent MySQL storage at `./data/mysql`, and a folder for the Ampache configuration file at `./data/config`.
+Beware that `/media` within the container should also be writeable by `www-data` (also within the container) in order for uploads to work:
+
+```bash
+# Give the www-data group write access to the /media folder
+docker-compose exec ampache bash -c "chgrp www-data /media && chmod g+w /media"
+```
 
 ## Running on ARM
 


### PR DESCRIPTION
If /media isn't writable, then uploads won't work.
That may be necessary for servers that would like uploads to be possible