### PR TITLE
Updates to readme, remove volumes from dockerfile, copy .dist files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN     apt-get -q -q update \
           unzip \
     &&  apt-get -qq autoremove
 
-VOLUME ["/etc/mysql", "/var/lib/mysql", "/media", "/var/www/config", "/var/www/themes"]
+VOLUME ["/etc/mysql", "/var/lib/mysql", "/var/www/config"]
 EXPOSE 80
 
 COPY run.sh inotifywatch.sh cron.sh apache2.sh mysql.sh create_mysql_admin_user.sh ampache_cron.sh docker-entrypoint.sh /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ The automated builds for the official repo are now built for linux/amd64, linux/
 
 After installation you will need to setup a catalog. Make sure to use `/media` as the path where your media is located.
 
+## Themes
+
+By default Ampache only ships with one theme built-in located at `/var/www/public/themes/reborn`. We want to avoid mounting the whole `/themes` directory otherwise the reborn theme will not be updated when the Amapche image updates. It's best to make a copy of the existing theme and then we can mount it in the `/themes` directory as a new theme.
+
+Make sure that the container is already running then copy the current theme to a folder on the host:
+
+```shell
+docker run -d --name=ampache ampache/ampache
+docker cp ampache:/var/www/public/themes/reborn ./data/new-theme
+docker container stop ampache
+```
+
+Now make modifications to the theme and then start the container again this time mounting the new theme to the container:
+
+```shell
+docker run -d --name=ampache -v ./data/new-theme:/var/www/public/themes/new-theme
+```
+
 ## Thanks to
 
 * @ericfrederich for his original work

--- a/README.md
+++ b/README.md
@@ -1,68 +1,90 @@
 # ampache-docker
 
-Docker container for Ampache, a web based audio/video streaming application and file manager allowing you to access your music & videos from anywhere, using almost any internet enabled device.
+Docker image for Ampache, a web based audio/video streaming application and file manager allowing you to access your music & videos from anywhere, using almost any internet enabled device.
 
-## build status
+## How to use this image
 
-![travis status](https://travis-ci.org/ampache/ampache-docker.svg?branch=master)
-
-## Develop build status
-
-![travis status](https://travis-ci.org/ampache/ampache-docker.svg?branch=develop)
-
-## noSQL build status
-
-![travis status](https://travis-ci.org/ampache/ampache-docker.svg?branch=nosql)
-
-## Usage
+This section covers two methods for running Ampache, first with the `docker run` command, and then using `docker-compose`.
 
 ### docker run
 
-To run official builds from docker hub you can run these commands:
-
-To run the current Ampache master (stable) branch
+To run the current Ampache master (stable) branch:
 
 ```bash
 docker run --name=ampache -d -v /path/to/your/music:/media:ro -p 80:80 ampache/ampache
 ```
 
-To run the current Ampache master (stable) branch **without an SQL server!**
-
-```bash
-docker run --name=ampache -d -v /path/to/your/music:/media:ro -p 80:80 ampache/ampache:nosql
-```
-
-To run the current Ampache develop branch
-
-```bash
-docker run --name=ampache -d -v /path/to/your/music:/media:ro -p 80:80 ampache/ampache:develop
-```
-
-~~The develop tag is set up to use git updates so you don't have to rebuild your images to stay up to date with development.~~
-
 ### docker-compose
 
-This method is recommended as it creates persistent volumes for important data. Included in the [GitHub repository](https://github.com/ampache/ampache-docker/blob/master/docker-compose.yml) is a simple `docker-compose.yml` file to get started. Use the following commands:
+This method is recommended as it creates persistent volumes for important data and makes restarting the container much easier.
+
+If you're already using Docker Desktop for Windows or Mac then Docker Compose is included. If you are using a different version or on Linux, follow these instructions in the docker docs: [Install Docker Compose](https://docs.docker.com/compose/install/)
+
+In the [GitHub repository](https://github.com/ampache/ampache-docker/blob/master/docker-compose.yml) is a simple `docker-compose.yml` file to get started. Download the file and run this command to start an Ampache container:
 
 ```bash
 docker-compose up -d
 ```
 
-The first time you run the container, you will also need to set the correct permissions on the configuration folder:
+This automatically creates the following bind mounts:
+
+* `./data/media` mounted at `/media` for music
+* `./data/mysql` mounted at `/var/lib/mysql` for persistent MySQL storage
+* `./data/config` mounted at `/var/www/config` for persistent Ampache configuration
+* `./data/log` mounted at `/var/log/ampache` for debug logs
+
+### Permissions
+
+In the container the webserver runs as the http user (UID and GID 33). If you created the directories manually, it is important to ensure that the Ampache Configuration, and log directories are readable and writeable by that user.
 
 ```bash
-chown www-data:www-data ./data/config -R
+chown 33:33 ./data/config -R
+chown 33:33 ./data/log
 ```
 
-This will automatically create mount points for music at `./data/media`, persistent MySQL storage at `./data/mysql`, and a folder for the Ampache configuration file at `./data/config`.
-Beware that `/media` within the container should also be writeable by `www-data` (also within the container) in order for uploads to work:
+Optionally, the media directory should be writable as if you wish to allow uploads.
 
 ```bash
-# Give the www-data group write access to the /media folder
-docker-compose exec ampache bash -c "chgrp www-data /media && chmod g+w /media"
+chgrp 33 ./data/media && chmod g+w ./data/media
 ```
 
-When creating a catalog, use `/media` as path which points to your mounted media files.
+## Image Variants
+
+For more advanced users a few different image variants are available.
+
+### `ampache:version`
+
+![travis status](https://travis-ci.org/ampache/ampache-docker.svg?branch=master)
+
+**Recommended**: Specifies a particular version from the Ampache master (stable) branch. Pinning Ampache to a specific version can prevent issues where you unexpectedly update a major version of Ampache with breaking changes you're not aware of.
+
+Use something like [Diun](https://crazymax.dev/diun/) to monitor for updates to the image.
+
+### `ampache:latest`
+
+![travis status](https://travis-ci.org/ampache/ampache-docker.svg?branch=master)
+
+Pulls the most recent image from the Master (stable) branch
+
+### `ampache:develop`
+
+![travis status](https://travis-ci.org/ampache/ampache-docker.svg?branch=develop)
+
+Pulls the most recent image from the Develop branch. This is generally safe to run but can break occasionally. Contains the latest features and updates.
+
+~~The develop tag is set up to use git updates so you don't have to rebuild your images to stay up to date with development.~~
+
+### `ampache:nosql`
+
+![travis status](https://travis-ci.org/ampache/ampache-docker.svg?branch=nosql)
+
+For advanced users, this provides an image without a MySQL server built-in. You must provide your own MySQL server.
+
+### `ampache:nosql<version>`
+
+![travis status](https://travis-ci.org/ampache/ampache-docker.svg?branch=nosql)
+
+The `nosql` image pinned to a specific version.
 
 ## Running on ARM
 
@@ -74,7 +96,7 @@ The automated builds for the official repo are now built for linux/amd64, linux/
 2. On the **Insert Ampache Database** page:
     1. **MySQL Administrative Username**: admin
     2. **MySQL Administrative Password**: (see container output)
-        * The logs will show a line that says `mysql -uadmin -pjnzYXLz7cMzq -h<host> -P<port>`. The password is everything after `-p`, in this case `jnzYXLz7cMzq`.
+        * The logs will show a line like: `mysql -uadmin -pjnzYXLz7cMzq -h<host> -P<port>`. The password is everything after `-p`, in this case `jnzYXLz7cMzq`.
     3. Check **Create Database User**
     4. **Ampache Database User Password**: Enter anything
     5. Click **Insert Database**
@@ -86,6 +108,8 @@ The automated builds for the official repo are now built for linux/amd64, linux/
 5. **Ampache Update** page:
     1. Click **Update Now!**
     2. Click [Return to main page] to login using previously entered credentials
+
+After installation you will need to setup a catalog. Make sure to use `/media` as the path where your media is located.
 
 ## Thanks to
 

--- a/run.sh
+++ b/run.sh
@@ -10,5 +10,8 @@ else
     echo "=> Using an existing volume of MySQL"
 fi
 
+# Copy Ampache config .dist files
+cp /var/tmp/* /var/www/config/
+
 # Start Supervisor to manage all the processes
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
`Dockerfile` changes:

* Remove `/media`. Doesn't make sense to include by default. If this isn't mounted then an anonymous volume is created, adds bloat. In almost all cases this should be mounted by the user anyway.
* Remove `/var/www/themes`. There really is no reason this needs to be mounted by default. It is bad to encourage mounting this, because if a user bind-mounts it to their system then the theme files will never get updated, as when a bind-mount is not empty then it replaces whatever is in the container.

`README.md` changes:

Mostly just refactoring and re-organizing the layout to mimic the README's of the official Docker images. Added some extra information for clarity.

`run.sh` changes:

This must have been removed accidentally some time ago, but when the image is built the `.dist` config files are copied into `/var/tmp`. These should be then overwrite existing files on image start in `/var/www/config`, since these files will not be updated otherwise due to the aforementioned behavior of bind mounts. 