### PR TITLE
Fix container overwriting ampache.cfg.php file

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ else
 fi
 
 # Copy Ampache config .dist files
-cp /var/tmp/* /var/www/config/
+cp /var/tmp/*.dist /var/www/config/
 
 # Start Supervisor to manage all the processes
 exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
I made a big mistake, and didn't realize that the `/var/temp` directory also includes an `ampache.cfg.php` file which will overwrite an existing one. I thought it only contained `.dist` files by default.

Must push this quickly so that people don't overwrite all their config files accidentally.