### PR TITLE
Change default http port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,11 +78,12 @@ RUN     apt-get -q -q update \
     &&  apt-get -qq autoremove
 
 VOLUME ["/etc/mysql", "/var/lib/mysql", "/var/www/config"]
-EXPOSE 80
+EXPOSE 4050
 
 COPY data/bin/run.sh data/bin/inotifywait.sh data/bin/cron.sh data/bin/apache2.sh data/bin/mysql.sh data/bin/create_mysql_admin_user.sh data/bin/ampache_cron.sh data/bin/docker-entrypoint.sh /usr/local/bin/
 COPY data/sites-enabled/001-ampache.conf /etc/apache2/sites-available/
 COPY data/config/ampache.cfg.* /var/tmp/
+COPY data/config/ports.conf /etc/apache2/
 COPY data/logrotate.d/* /etc/logrotate.d/
 COPY data/supervisord/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/data/config/ports.conf
+++ b/data/config/ports.conf
@@ -1,0 +1,18 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen 4050
+
+<IfModule ssl_module>
+	Listen 443
+</IfModule>
+
+<IfModule mod_gnutls.c>
+	Listen 443
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet
+
+
+


### PR DESCRIPTION
Default port 80 is not a good choice for running in host network, which you probably should when you want to run UPnP or MPD.