### PR TITLE
Let the database server stop gracefully

### DIFF
--- a/data/supervisord/supervisord.conf
+++ b/data/supervisord/supervisord.conf
@@ -10,6 +10,9 @@ command=cron.sh
 
 [program:mysql]
 command=mysql.sh
+stopwaitsecs=120
+stopasgroup=true
+killasgroup=true
 
 [program:apache2]
 command=apache2.sh


### PR DESCRIPTION
Updated supervisor configuration to send the SIGTERM and SIGKILL to all the group instead just the parent which is a shell script and not the actual server.