### PR TITLE
Add environment variable to disable clean on inotify

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ LABEL maintainer="lachlan-00"
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MYSQL_PASS **Random**
+ENV DISABLE_INOTIFYWAIT_CLEAN 0
 ARG VERSION=5.6.1
 
 RUN     sh -c 'echo "Types: deb\n# http://snapshot.debian.org/archive/debian/20230612T000000Z\nURIs: http://deb.debian.org/debian\nSuites: stable stable-updates\nComponents: main contrib non-free\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n\nTypes: deb\n# http://snapshot.debian.org/archive/debian-security/20230612T000000Z\nURIs: http://deb.debian.org/debian-security\nSuites: stable-security\nComponents: main\nSigned-By: /usr/share/keyrings/debian-archive-keyring.gpg\n" > /etc/apt/sources.list.d/debian.sources' \

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ This automatically creates the following bind mounts:
 * `./data/config` mounted at `/var/www/config` for persistent Ampache configuration
 * `./data/log` mounted at `/var/log/ampache` for debug logs
 
+### Environment variables
+
+You can configure parts of the container using environment variables. When running with `docker run`, you can set an environment variable using the `-e` parameter; for example, `-e FOO=BAR` sets the environemnt variable `FOO` to bar. When using `docker-compose`, you can set environment variables using a `.env` file in this directory.
+
+Available environment variables are:
+
+* `DISABLE_INOTIFYWAIT_CLEAN`: If set to 1, disables the clean step on the directory monitor. This prevents Ampache from automatically cleaning files. If you are using a bind mount on an external storage, this may be desirable as it prevents Ampache from removing files if the external storage goes down.
+
 ### Permissions
 
 In the container the webserver runs as the http user (UID and GID 33). If you created the directories manually, it is important to ensure that the Ampache Configuration, and log directories are readable and writeable by that user.

--- a/data/bin/inotifywait.sh
+++ b/data/bin/inotifywait.sh
@@ -50,7 +50,11 @@ inotifywait -m -r --event close_write --event moved_to --event create --event de
         do
             if [[ "$file" =~ .*$i$ ]]; then
                 echo "$file"
-                php /var/www/bin/cli run:updateCatalogFile -n music -f "$file" -cage
+                if [["$DISABLE_INOTIFYWAIT_CLEAN" == "1"]]; then
+                    php /var/www/bin/cli run:updateCatalogFile -n music -f "$file" -age
+                else
+                    php /var/www/bin/cli run:updateCatalogFile -n music -f "$file" -cage
+                fi
             fi
         done
     done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,5 @@ services:
       - ./data/log:/var/log/ampache
       - ./data/media:/media
       - ./data/mysql:/var/lib/mysql
+  environment:
+    DISABLE_INOTIFYWAIT_CLEAN: ${DISABLE_INOTIFYWAIT_CLEAN-0}


### PR DESCRIPTION
When using ampache on external storage that doesn't have a guaranteed availability, the inotifywait monitor will clean the catalogue if the external storage goes down. This adds a new environment variable to docker that switches the monitor from running `-cage` to running `-age` instead.

That way, if the external storage is unavailable, the catalogue is preserved rather than automatically deleted. (`-age` doesn't remove files if they don't exist).

Decided to write this patch since ampache kept removing my catalogue data whenever the external storage I used went down due to connection issues.