### PR TITLE
replace obsolete version with name element

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+name: ampache
 
 services:
   ampache:


### PR DESCRIPTION
The version to level element is now obsolete and a warning shows in docker compose when using it.

In addition a new name top level element is added.

Read more [here](https://docs.docker.com/reference/compose-file/version-and-name/)