### PR TITLE
Fix inotifywait.sh: run:updateCatalogFile invalid flag syntax silently breaks auto-catalog-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Available environment variables are:
 * `MYSQL_USER`: Set your own MySql admin username (Default: admin)
 * `MYSQL_PASS`: Set your own MySql admin password (Or one will be randomly generated for you)
 * `DISABLE_INOTIFYWAIT_CLEAN`: If set to 1, disables the clean step on the directory monitor. This prevents Ampache from automatically cleaning files. If you are using a bind mount on an external storage, this may be desirable as it prevents Ampache from removing files if the external storage goes down.
+* `CATALOG_NAME`: Name of the Ampache catalog that the directory monitor (`inotifywait.sh`) should update when files change under `/media`. Must match an existing catalog name. (Default: music)
 * `LOG_FILE`: Full file path to ampache log file inside the container. (Default: /var/log/ampache/ampache.log) When available it will print log file data to the docker logs command. (e.g. `docker logs ampache`)
 
 #### Automated install

--- a/data/bin/inotifywait.sh
+++ b/data/bin/inotifywait.sh
@@ -16,32 +16,27 @@
 #    delete_self   file or directory was deleted
 #    unmount       file system containing file or directory unmounted
 
-# cli command run:updateCatalog
+# cli command run:updateCatalogFile
 #
-# Perform catalog actions for all files of a catalog. If no options are given, the defaults actions -ceag are assumed
+# Perform catalog actions for a single file.
 #
-# Usage: run:updateCatalog [OPTIONS...] [ARGUMENTS...]
+# Usage: run:updateCatalogFile <catalogName> <filePath> [OPTIONS...]
 #
 # Arguments:
-#   [catalogName]    Name of Catalogue (optional)
-#   [catalogType]    Type of Catalogue (optional)
+#   <catalogName>    Catalog Name
+#   <filePath>       File Path
 #
 # Options:
-#   [-a|--add]            Adds new media files to the database
-#   [-g|--art]            Gathers media Art
-#   [-c|--cleanup]        Removes missing files from the database
-#   [-f|--find]           Find missing files and print a list of filenames
-#   [-h|--help]           Show help
-#   [-i|--import]         Adds new media files and imports playlist files
-#   [-m|--memorylimit]    Temporarily deactivates PHP memory limit
-#   [-o|--optimize]       Optimises database tables
-#   [-u|--update]         Update local object metadata using external plugins
-#   [-v|--verbosity]      Verbosity level
-#   [-e|--verify]         Reads your files and updates the database to match changes
-#   [-V|--version]        Show version
+#   [-a|--add]        Adds new media files to the database
+#   [-g|--art]        Gathers media Art
+#   [-c|--cleanup]    Removes missing files from the database
+#   [-e|--verify]     Reads your files and updates the database to match changes
 
 # music file extensions to look for
 declare -a arr=("mp3" "mpc" "m4p" "m4a" "aac" "ogg" "oga" "wav" "aif" "aiff" "rm" "wma" "asf" "flac" "opus" "spx" "ra" "ape" "shn" "wv")
+
+# name of the Ampache catalog to update (must match an existing catalog name)
+CATALOG_NAME="${CATALOG_NAME:-music}"
 
 # monitor your media folder for updates
 inotifywait -m -r --event close_write --event moved_to --event create --event delete --format '%w%f' /media |
@@ -50,10 +45,10 @@ inotifywait -m -r --event close_write --event moved_to --event create --event de
         do
             if [[ "$file" =~ .*$i$ ]]; then
                 echo "$file"
-                if [["$DISABLE_INOTIFYWAIT_CLEAN" == "1"]]; then
-                    php /var/www/bin/cli run:updateCatalogFile -n music -f "$file" -age
+                if [[ "$DISABLE_INOTIFYWAIT_CLEAN" == "1" ]]; then
+                    php /var/www/bin/cli run:updateCatalogFile "$CATALOG_NAME" "$file" -a -e -g
                 else
-                    php /var/www/bin/cli run:updateCatalogFile -n music -f "$file" -cage
+                    php /var/www/bin/cli run:updateCatalogFile "$CATALOG_NAME" "$file" -a -c -e -g
                 fi
             fi
         done


### PR DESCRIPTION
## Problem

`data/bin/inotifywait.sh` watches `/media` and, on every detected file change, runs:

```bash
php /var/www/bin/cli run:updateCatalogFile -n music -f "$file" -cage
```

But `run:updateCatalogFile` takes the catalog name and file path as **positional** arguments, not `-n`/`-f` flags:

```
Usage: run:updateCatalogFile [OPTIONS...] [ARGUMENTS...]
Arguments:
  <catalogName>    Catalog Name
  <filePath>       File Path
```

Because of this mismatch, the command fails to parse its arguments and just prints its own help/usage text instead of running — every single time, for every file. The net effect is that automatic catalog updates on file add/move/rename **never actually happen**, silently. There's no error, just usage text buried in a log nobody watches. Users only notice indirectly, e.g. newly added folders/artists returning "not found" when browsing in a Subsonic-API client.

There's also a syntax bug in the `DISABLE_INOTIFYWAIT_CLEAN` conditional — `[["$DISABLE_INOTIFYWAIT_CLEAN" == "1"]]` is missing the required spaces around `[[`/`]]`, so bash treats `[["$DISABLE_INOTIFYWAIT_CLEAN"` as an (nonexistent) command rather than a test expression. It always falls through to the `else` branch regardless of the env var's value.

## Fix

- Call `run:updateCatalogFile` with the catalog name and file path as positional arguments, and pass `-a -c -e -g` / `-a -e -g` as separate option flags.
- Fix the `[[ ... ]]` spacing so the `DISABLE_INOTIFYWAIT_CLEAN` check actually works.
- The catalog name was hardcoded to `"music"`, which only works if a catalog happens to be named exactly that. Pulled it out into a `CATALOG_NAME` env var (default `music`, so existing setups relying on the default behavior see no change), documented in the README alongside the other env vars.

## Verification

Reproduced against a live `ampache/ampache:latest` container (Ampache 7.9.8): before the fix, every `close_write`/`create`/`moved_to`/`delete` event under `/media` logged the file path followed by `run:updateCatalogFile`'s usage/help dump. After deploying the corrected script and restarting the watcher, the same events correctly invoke `run:updateCatalogFile <catalog> <path> -a -c -e -g` and the file is added/verified in the catalog (confirmed via direct DB query and by triggering a real file event).